### PR TITLE
Remove GZIP compression for WOFF2 files

### DIFF
--- a/main/http_server/axe-os/only-gzip.js
+++ b/main/http_server/axe-os/only-gzip.js
@@ -16,7 +16,7 @@ function processDirectory(dirPath) {
                 if (stats.isDirectory()) {
                     // If it's a directory, process it recursively
                     processDirectory(filePath);
-                } else if (!file.endsWith('.gz')) {
+                } else if (!['.gz', '.woff2'].some(ext => file.endsWith(ext))) {
                     // If it's a file and doesn't end with .gz, unlink it
                     fs.unlink(filePath, (err) => {
                         if (err) throw err;

--- a/main/http_server/axe-os/package.json
+++ b/main/http_server/axe-os/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --configuration=production && gzipper compress --verbose --gzip --gzip-level 9 ./dist/axe-os && node only-gzip.js",
+    "build": "ng build --configuration=production && gzipper compress --verbose --gzip --gzip-level 9 --exclude woff2 ./dist/axe-os && node only-gzip.js",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "bundle-report": "ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/axe-os/stats.json"

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -363,7 +363,9 @@ static esp_err_t rest_common_get_handler(httpd_req_t * req)
         httpd_resp_set_hdr(req, "Cache-Control", "max-age=2592000");
     }
 
-    httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+    if (!CHECK_FILE_EXTENSION(filepath, ".woff2")) {
+        httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+    }
 
     char * chunk = rest_context->scratch;
     ssize_t read_bytes;


### PR DESCRIPTION
> WOFF2 files are already compressed, so applying additional gzip or deflate compression to them typically has little to no effect. This is because the WOFF2 file format internally compresses the font data, making further compression redundant.

Since WOFF2 files are already compressed, it makes no sense to compress them again and have the browser decompress them. This PR adds an exception for compression during the build process.

**Build current state**
```
gzipper: File assets/fonts/AngelWish.woff2 has been compressed. 
Algorithm: GZIP 
Size: 30.22 KB -> 30.22 KB 
Time: 5.933517ms

gzipper: File assets/fonts/Nippo-Regular.woff2 has been compressed. 
Algorithm: GZIP 
Size: 15.51 KB -> 15.53 KB 
Time: 21.031808ms

gzipper: File assets/fonts/primeicons.woff2 has been compressed. 
Algorithm: GZIP 
Size: 34.32 KB -> 34.35 KB 
Time: 8.116565ms
```

**Todos**
- [x] An exception for `gzipper` was added.
- [x] An exception for `unlink` added to `gzip-only.js`.
- [x] An exception for the HTTP header `Content-Encoding:gzip` was added.

**Warning: Not tested on a real device (a Bitaxe is on the way).**

**After some exceptions**
<img width="775" alt="Screenshot 2025-06-18 at 07 30 40" src="https://github.com/user-attachments/assets/5c1eadd9-6784-41c9-a495-0b3d01add87f" />