### PR TITLE
device ident + restart toast fix

### DIFF
--- a/main/http_server/axe-os/src/app/components/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/components/system/system.component.ts
@@ -110,7 +110,7 @@ export class SystemComponent implements OnInit, OnDestroy {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: (result) => {
-          this.toastr.success(result);
+          this.toastr.success(result.message);
         },
         error: (err: HttpErrorResponse) => {
           this.toastr.error(`Could not identify device. ${err.message}`);

--- a/main/http_server/axe-os/src/app/components/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/components/system/system.component.ts
@@ -6,7 +6,7 @@ import { SystemApiService } from 'src/app/services/system.service';
 import { LoadingService } from 'src/app/services/loading.service';
 import { DateAgoPipe } from 'src/app/pipes/date-ago.pipe';
 import { ByteSuffixPipe } from 'src/app/pipes/byte-suffix.pipe';
-import { SystemInfo as ISystemInfo, SystemASIC as ISystemASIC, } from 'src/app/generated';
+import { SystemInfo as ISystemInfo, SystemASIC as ISystemASIC, GenericResponse, } from 'src/app/generated';
 
 type TableRow = {
   label: string;
@@ -110,7 +110,7 @@ export class SystemComponent implements OnInit, OnDestroy {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: (result) => {
-          this.toastr.success(result.message);
+          this.toastr.success((result as GenericResponse).message);
         },
         error: (err: HttpErrorResponse) => {
           this.toastr.error(`Could not identify device. ${err.message}`);

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -147,7 +147,6 @@ export class SystemApiService {
     }
 
     if (environment.production && this.generatedSystemService) {
-      console.log(columnList)
       return this.generatedSystemService.getSystemStatistics(columnList).pipe(timeout(API_TIMEOUT));
     }
 

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -147,6 +147,7 @@ export class SystemApiService {
     }
 
     if (environment.production && this.generatedSystemService) {
+      console.log(columnList)
       return this.generatedSystemService.getSystemStatistics(columnList).pipe(timeout(API_TIMEOUT));
     }
 
@@ -212,7 +213,7 @@ export class SystemApiService {
     }
 
     if (environment.production && uri) {
-      return this.httpClient.post(`${uri}/api/system/restart`, {}, { responseType: 'text' });
+      return this.httpClient.post(`${uri}/api/system/restart`, {});
     }
 
     return of('Device restarted (mock)');
@@ -224,7 +225,7 @@ export class SystemApiService {
     }
 
     if (environment.production && uri) {
-      return this.httpClient.post(`${uri}/api/system/identify`, {}, { responseType: 'text' });
+      return this.httpClient.post(`${uri}/api/system/identify`, {});
     }
 
     return of('Device identified (mock)');

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -718,17 +718,23 @@ static esp_err_t POST_identify(httpd_req_t * req)
 
     ESP_LOGI(TAG, "Identify mode enabled for 30s");
 
-    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_set_type(req, "application/json");
+
+    cJSON * root = cJSON_CreateObject();
 
     if (GLOBAL_STATE->SYSTEM_MODULE.identify_mode_time_ms > 0) {
         GLOBAL_STATE->SYSTEM_MODULE.identify_mode_time_ms = 0;
-        httpd_resp_send(req, "The device no longer says \"Hi!\".", HTTPD_RESP_USE_STRLEN);
+        cJSON_AddStringToObject(root, "message", "The device no longer says \"Hi!\".");
     } else {
         GLOBAL_STATE->SYSTEM_MODULE.identify_mode_time_ms = 30000;
-        httpd_resp_send(req, "The device says \"Hi!\" for 30 seconds.", HTTPD_RESP_USE_STRLEN);
+         cJSON_AddStringToObject(root, "message", "The device says \"Hi!\" for 30 seconds.");
     }
 
-    return ESP_OK;
+    esp_err_t res = HTTP_send_json(req, root, &api_common_prebuffer_len);
+
+    cJSON_Delete(root);
+
+    return res;
 }
 
 static esp_err_t POST_restart(httpd_req_t * req)

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -751,11 +751,16 @@ static esp_err_t POST_restart(httpd_req_t * req)
 
     ESP_LOGI(TAG, "Restarting System because of API Request");
 
-    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_set_type(req, "application/json");
+
+    cJSON * root = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(root, "message", "System will restart shortly.");
 
     // Send HTTP response before restarting
-    const char* resp_str = "System will restart shortly.";
-    httpd_resp_send(req, resp_str, HTTPD_RESP_USE_STRLEN);
+    esp_err_t res = HTTP_send_json(req, root, &api_common_prebuffer_len);
+
+    cJSON_Delete(root);
 
     // Delay to ensure the response is sent
     vTaskDelay(1000 / portTICK_PERIOD_MS);
@@ -764,7 +769,7 @@ static esp_err_t POST_restart(httpd_req_t * req)
     esp_restart();
 
     // This return statement will never be reached, but it's good practice to include it
-    return ESP_OK;
+    return res;
 }
 
 static const char* esp_reset_reason_to_string(esp_reset_reason_t reason) {

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -721,6 +721,10 @@ static esp_err_t POST_identify(httpd_req_t * req)
     httpd_resp_set_type(req, "application/json");
 
     cJSON * root = cJSON_CreateObject();
+    if (root == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
+        return ESP_OK;
+    }
 
     if (GLOBAL_STATE->SYSTEM_MODULE.identify_mode_time_ms > 0) {
         GLOBAL_STATE->SYSTEM_MODULE.identify_mode_time_ms = 0;

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -754,6 +754,10 @@ static esp_err_t POST_restart(httpd_req_t * req)
     httpd_resp_set_type(req, "application/json");
 
     cJSON * root = cJSON_CreateObject();
+    if (root == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
+        return ESP_OK;
+    }
 
     cJSON_AddStringToObject(root, "message", "System will restart shortly.");
 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -793,6 +793,16 @@ paths:
       responses:
         '200':
           description: Device identify initiated
+          content:
+           application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+              
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -805,9 +805,9 @@ paths:
         '200':
           description: Device identify initiated
           content:
-           application/json:
+            application/json:
               schema:
-                "$ref": "#/components/schemas/GenericResponse"
+                '$ref': '#/components/schemas/GenericResponse'
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -17,6 +17,13 @@ servers:
 
 components:
   schemas:
+    GenericResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
     SharesRejectedReason:
       type: object
       required:
@@ -778,6 +785,10 @@ paths:
       responses:
         '200':
           description: System restart initiated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericResponse'
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':
@@ -796,13 +807,7 @@ paths:
           content:
            application/json:
               schema:
-                type: object
-                required:
-                  - message
-                properties:
-                  message:
-                    type: string
-              
+                "$ref": "#/components/schemas/GenericResponse"
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':


### PR DESCRIPTION
a side effect of the generated code is device ident and restarting were erroring cause the endpoints return a string, and the code is expecting to parse a json object. i gave them a basic `{"message": string}` uwu

<img width="600" height="248" alt="image" src="https://github.com/user-attachments/assets/e699ce81-bf10-4285-93ea-da7dd7e0f104" />
