### PR TITLE
Fix initial chart size for gridstack migration

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.scss
+++ b/main/http_server/axe-os/src/app/components/home/home.component.scss
@@ -22,7 +22,6 @@
 
 // Gridstack layout
 .grid-stack {
-    --gs-cell-height: 39px;
     margin: -8px;
 
     .grid-stack-item-content {

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -48,19 +48,20 @@ interface ISystemInfoError {
 const HOME_CHART_DATA_SOURCES = 'HOME_CHART_DATA_SOURCES';
 const DASHBOARD_LAYOUT_KEY = 'DASHBOARD_LAYOUT_V1';
 const HIDDEN_WIDGETS_KEY = 'DASHBOARD_HIDDEN_WIDGETS';
+const DEFAULT_CELL_HEIGHT = 40;
 
 const WIDGET_DEFAULTS: WidgetDef[] = [
   { id: 'hashrate',    label: 'Hashrate',            x: 0, y: 0,   w: 3,  h: 5,  minW: 2, minH: 3 },
   { id: 'efficiency',  label: 'Efficiency',          x: 3, y: 0,   w: 3,  h: 5,  minW: 2, minH: 3 },
   { id: 'shares',      label: 'Shares',              x: 6, y: 0,   w: 3,  h: 5,  minW: 2, minH: 3 },
   { id: 'bestdiff',    label: 'Best Difficulty',     x: 9, y: 0,   w: 3,  h: 5,  minW: 2, minH: 3 },
-  { id: 'chart',       label: 'Chart',               x: 0, y: 5,   w: 12, h: 23, minW: 4, minH: 10 },
-  { id: 'power',       label: 'Power',               x: 0, y: 28,  w: 4,  h: 7,  minW: 2, minH: 3 },
-  { id: 'heat',        label: 'Heat',                x: 4, y: 28,  w: 4,  h: 7,  minW: 2, minH: 3 },
-  { id: 'fan',         label: 'Fan',                 x: 8, y: 28,  w: 4,  h: 7,  minW: 2, minH: 3 },
-  { id: 'pool',        label: 'Pool',                x: 0, y: 35,  w: 4,  h: 6,  minW: 2, minH: 3 },
-  { id: 'blockheader', label: 'Block Header',        x: 4, y: 35,  w: 4,  h: 6,  minW: 2, minH: 3 },
-  { id: 'registers',   label: 'Hashrate Registers',  x: 8, y: 35,  w: 4,  h: 6,  minW: 2, minH: 3 },
+  { id: 'chart',       label: 'Chart',               x: 0, y: 5,   w: 12, h: 0,  minW: 4, minH: 8 },
+  { id: 'power',       label: 'Power',               x: 0, y: 5,   w: 4,  h: 7,  minW: 2, minH: 3 },
+  { id: 'heat',        label: 'Heat',                x: 4, y: 5,   w: 4,  h: 7,  minW: 2, minH: 3 },
+  { id: 'fan',         label: 'Fan',                 x: 8, y: 5,   w: 4,  h: 7,  minW: 2, minH: 3 },
+  { id: 'pool',        label: 'Pool',                x: 0, y: 12,  w: 4,  h: 6,  minW: 2, minH: 3 },
+  { id: 'blockheader', label: 'Block Header',        x: 4, y: 12,  w: 4,  h: 6,  minW: 2, minH: 3 },
+  { id: 'registers',   label: 'Hashrate Registers',  x: 8, y: 12,  w: 4,  h: 6,  minW: 2, minH: 3 },
 ];
 
 @Component({
@@ -198,7 +199,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.loadPreviousData();
   }
 
-
   @HostListener('window:resize')
   onWindowResize() {
     clearTimeout(this.resizeTimer);
@@ -237,7 +237,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     this.grid = GridStack.init({
       column: 12,
-      cellHeight: 39,
+      cellHeight: DEFAULT_CELL_HEIGHT,
       margin: 8,
       float: false,
       disableResize: true,
@@ -254,8 +254,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     }, this.gridStackEl!.nativeElement);
 
     const savedLayout = this.storageService.getObject(DASHBOARD_LAYOUT_KEY);
-    this.grid.load(savedLayout ?? WIDGET_DEFAULTS);
-
+    this.grid.load(savedLayout ?? this.getInitialLayout());
 
     setTimeout(() => this.chart?.chart?.resize(), 100);
 
@@ -286,7 +285,29 @@ export class HomeComponent implements OnInit, OnDestroy {
   public resetLayout(): void {
     localStorage.removeItem(DASHBOARD_LAYOUT_KEY);
     localStorage.removeItem(HIDDEN_WIDGETS_KEY);
-    window.location.reload();
+    this.grid.load(this.getInitialLayout());
+  }
+
+  private getInitialLayout(): WidgetDef[] {
+    const chartDef = WIDGET_DEFAULTS.find(d => d.id === 'chart');
+    if (!chartDef) return WIDGET_DEFAULTS;
+
+    // The old layout set the chart height to 40vh. In gridstack, you need to set the height of 
+    // the card, so there's 100px to compensate for the dropdowns and padding.
+    const CHART_CHROME_PX = 100;
+    const targetPx = (window.innerHeight * 0.40) + CHART_CHROME_PX;
+    const chartH = Math.max(chartDef.minH ?? 8, Math.round(targetPx / DEFAULT_CELL_HEIGHT));
+
+    return WIDGET_DEFAULTS.map(widget => {
+      const w = { ...widget };
+      if (w.id === chartDef.id) {
+        w.h = chartH;
+      } else if (w.y >= chartDef.y) {
+        // Shift everything at or below the chart position
+        w.y += chartH;
+      }
+      return w;
+    });
   }
 
   public isWidgetVisible(id: string): boolean {


### PR DESCRIPTION
This mimics the old dashboard resizing behaviour. It calculates the desired height in cells for the chart card as 40% of the viewport height. It takes into account that the old dashboard sized the chart itself, not the card. To compensate it adds 100px to account for the dropdowns and padding. This takes the size of the chart within 20px of the old dashboard.

This code only runs when there's no stored layout, or when the layout is reset.